### PR TITLE
Add support for checking links for availability from the Internet Archive and displaying the reference

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,18 @@
 import "@logseq/libs";
 import { archive } from "archive";
+import { settings } from "settings";
 import { hash } from "utils";
 
 function main() {
+  settings();
+
   logseq.Editor.registerSlashCommand(
     "🌐 Archive Webpage",
     async () => await logseq.Editor.insertAtEditingCursor(`{{renderer archive `)
+  );
+
+  logseq.Editor.registerSlashCommand("Archive Webpage Settings", async () =>
+    logseq.showSettingsUI()
   );
 
   logseq.App.onMacroRendererSlotted(({ slot, payload }) => {
@@ -27,11 +34,20 @@ function main() {
 
       try {
         logseq.provideUI(render(key, "Archiving..."));
-        const filePath = await archive(url);
+        const { localPath, internetArchiveUrl } = await archive(url);
+
+        const links: Link[] = [
+          { key: "Archive", value: localPath },
+          { key: "Internet Archive", value: internetArchiveUrl },
+        ];
+
         logseq.provideUI(
           render(
             key,
-            `<a href="${url}" target="_blank">${url}</a> (<a href="${filePath}" target="_blank">Archived</a>)`
+            `<a href="${url}" target="_blank">${url}</a> ${links
+              .filter((link) => link.value)
+              .map(a)
+              .join(" ")}`
           )
         );
       } catch (err: any) {
@@ -42,3 +58,7 @@ function main() {
 }
 
 logseq.ready(main).catch(console.error);
+
+type Link = { key: string; value?: string };
+const a = ({ key, value }: Link) =>
+  `(<a href="${value}" target="_blank">${key}</a>)`;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,21 @@
+import "@logseq/libs";
+import { SettingSchemaDesc } from "@logseq/libs/dist/LSPlugin.user";
+
+export enum Settings {
+  UseInternetArchive = 'UseInternetArchive'
+}
+
+/** Loads the settings schema. */
+export const settings = () => {
+  const settingsTemplate: SettingSchemaDesc[] = [
+    {
+      key: Settings.UseInternetArchive,
+      type: "boolean",
+      title: "Use Internet Archive",
+      description:
+        "Enables the use of Internet Archive for managing archived webpages.",
+      default: true,
+    },
+  ];
+  logseq.useSettingsSchema(settingsTemplate);
+};


### PR DESCRIPTION
<img width="931" alt="Screenshot 2023-11-10 at 11 18 44 PM" src="https://github.com/patmigliaccio/logseq-archive-webpage/assets/5942599/33fe6f68-f2f3-4b6b-9ecc-75c2d3d8c6a6">

<img width="931" alt="Screenshot 2023-11-10 at 11 27 31 PM" src="https://github.com/patmigliaccio/logseq-archive-webpage/assets/5942599/b9da638a-dda4-44f9-9694-a7b39551be88">

<img width="931" alt="Screenshot 2023-11-10 at 11 28 04 PM" src="https://github.com/patmigliaccio/logseq-archive-webpage/assets/5942599/fe221604-3576-4e27-ae06-fd94baf6ad3b">


* Add the additional check for availability of the URL in the Internet Archive (optional)
* Add a setting to disable remote requests to the Internet Archive
* Add a new slash command: `/Archive Webpage Settings` for opening the plugin settings